### PR TITLE
Allow macro inputs from workspace crates inside nested folders

### DIFF
--- a/utoipauto-core/Cargo.lock
+++ b/utoipauto-core/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "utoipauto-core"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/utoipauto-core/src/attribute_utils.rs
+++ b/utoipauto-core/src/attribute_utils.rs
@@ -8,18 +8,16 @@ pub fn update_openapi_macro_attributes(
     uto_reponses: &String,
 ) {
     let mut is_ok = false;
-    #[warn(clippy::needless_range_loop)]
-    for i in 0..macro_attibutes.len() {
-        if !macro_attibutes[i].path().is_ident("openapi") {
+    for attr in macro_attibutes {
+        if !attr.path().is_ident("openapi") {
             continue;
         }
         is_ok = true;
-        let mut src_uto_macro = macro_attibutes[i].to_token_stream().to_string();
+        let mut src_uto_macro = attr.to_token_stream().to_string();
 
         src_uto_macro = src_uto_macro.replace("#[openapi(", "");
         src_uto_macro = src_uto_macro.replace(")]", "");
-        macro_attibutes[i] =
-            build_new_openapi_attributes(src_uto_macro, uto_paths, uto_models, uto_reponses);
+        *attr = build_new_openapi_attributes(src_uto_macro, uto_paths, uto_models, uto_reponses);
     }
     if !is_ok {
         panic!("No utoipa::openapi Macro found !");
@@ -58,7 +56,7 @@ pub fn build_new_openapi_attributes(
 fn remove_paths(src_uto_macro: String) -> String {
     if src_uto_macro.contains("paths(") {
         let paths = src_uto_macro.split("paths(").collect::<Vec<&str>>()[1];
-        let paths = paths.split(")").collect::<Vec<&str>>()[0];
+        let paths = paths.split(')').collect::<Vec<&str>>()[0];
         src_uto_macro
             .replace(format!("paths({})", paths).as_str(), "")
             .replace(",,", ",")
@@ -70,7 +68,7 @@ fn remove_paths(src_uto_macro: String) -> String {
 fn remove_schemas(src_uto_macro: String) -> String {
     if src_uto_macro.contains("schemas(") {
         let schemas = src_uto_macro.split("schemas(").collect::<Vec<&str>>()[1];
-        let schemas = schemas.split(")").collect::<Vec<&str>>()[0];
+        let schemas = schemas.split(')').collect::<Vec<&str>>()[0];
         src_uto_macro
             .replace(format!("schemas({})", schemas).as_str(), "")
             .replace(",,", ",")
@@ -82,7 +80,7 @@ fn remove_schemas(src_uto_macro: String) -> String {
 fn remove_components(src_uto_macro: String) -> String {
     if src_uto_macro.contains("components(") {
         let components = src_uto_macro.split("components(").collect::<Vec<&str>>()[1];
-        let components = components.split(")").collect::<Vec<&str>>()[0];
+        let components = components.split(')').collect::<Vec<&str>>()[0];
         src_uto_macro
             .replace(format!("components({})", components).as_str(), "")
             .replace(",,", ",")
@@ -94,7 +92,7 @@ fn remove_components(src_uto_macro: String) -> String {
 fn remove_responses(src_uto_macro: String) -> String {
     if src_uto_macro.contains("responses(") {
         let responses = src_uto_macro.split("responses(").collect::<Vec<&str>>()[1];
-        let responses = responses.split(")").collect::<Vec<&str>>()[0];
+        let responses = responses.split(')').collect::<Vec<&str>>()[0];
         src_uto_macro
             .replace(format!("responses({})", responses).as_str(), "")
             .replace(",,", ",")
@@ -106,7 +104,7 @@ fn remove_responses(src_uto_macro: String) -> String {
 fn extract_paths(src_uto_macro: String) -> String {
     if src_uto_macro.contains("paths(") {
         let paths = src_uto_macro.split("paths(").collect::<Vec<&str>>()[1];
-        let paths = paths.split(")").collect::<Vec<&str>>()[0];
+        let paths = paths.split(')').collect::<Vec<&str>>()[0];
         paths.to_string()
     } else {
         "".to_string()
@@ -116,7 +114,7 @@ fn extract_paths(src_uto_macro: String) -> String {
 fn extract_schemas(src_uto_macro: String) -> String {
     if src_uto_macro.contains("schemas(") {
         let schemas = src_uto_macro.split("schemas(").collect::<Vec<&str>>()[1];
-        let schemas = schemas.split(")").collect::<Vec<&str>>()[0];
+        let schemas = schemas.split(')').collect::<Vec<&str>>()[0];
         schemas.to_string()
     } else {
         "".to_string()
@@ -126,7 +124,7 @@ fn extract_schemas(src_uto_macro: String) -> String {
 fn extract_responses(src_uto_macro: String) -> String {
     if src_uto_macro.contains("responses(") {
         let responses = src_uto_macro.split("responses(").collect::<Vec<&str>>()[1];
-        let responses = responses.split(")").collect::<Vec<&str>>()[0];
+        let responses = responses.split(')').collect::<Vec<&str>>()[0];
         responses.to_string()
     } else {
         "".to_string()
@@ -168,7 +166,7 @@ mod test {
             )
             .to_token_stream()
             .to_string()
-            .replace(" ", ""),
+            .replace(' ', ""),
             "#[openapi(paths(./src),components(schemas(),responses()),)]".to_string()
         );
     }
@@ -184,7 +182,7 @@ mod test {
             )
             .to_token_stream()
             .to_string()
-            .replace(" ", ""),
+            .replace(' ', ""),
             "#[openapi(paths(./src,p1),components(schemas(),responses()),)]".to_string()
         );
     }
@@ -200,7 +198,7 @@ mod test {
             )
             .to_token_stream()
             .to_string()
-            .replace(" ", ""),
+            .replace(' ', ""),
             "#[openapi(paths(./src,p1),components(schemas(model),responses()),)]".to_string()
         );
     }
@@ -216,7 +214,7 @@ mod test {
             )
             .to_token_stream()
             .to_string()
-            .replace(" ", ""),
+            .replace(' ', ""),
             "#[openapi(paths(./src,p1),components(schemas(model,m1),responses()),)]".to_string()
         );
     }
@@ -232,7 +230,7 @@ mod test {
             )
             .to_token_stream()
             .to_string()
-            .replace(" ", ""),
+            .replace(' ', ""),
             "#[openapi(paths(./src,p1),components(schemas(),responses(response,r1)),)]".to_string()
         );
     }
@@ -248,7 +246,7 @@ mod test {
             )
             .to_token_stream()
             .to_string()
-            .replace(" ", ""),
+            .replace(' ', ""),
             "#[openapi(paths(./src,p1),components(schemas(model,m1),responses(response,r1)),)]"
                 .to_string()
         );
@@ -265,7 +263,7 @@ mod test {
             )
             .to_token_stream()
             .to_string()
-            .replace(" ", ""),
+            .replace(' ', ""),
             "#[openapi(paths(./src,p1),components(schemas(m1),responses(response,r1)),)]"
                 .to_string()
         );
@@ -282,7 +280,7 @@ mod test {
             )
             .to_token_stream()
             .to_string()
-            .replace(" ", ""),
+            .replace(' ', ""),
             "#[openapi(paths(./src,p1),components(schemas(model,m1),responses(r1)),)]".to_string()
         );
     }

--- a/utoipauto-core/src/file_utils.rs
+++ b/utoipauto-core/src/file_utils.rs
@@ -1,7 +1,8 @@
 use std::{
     fs::{self, File},
     io::{self, Read},
-    path::PathBuf,
+    iter,
+    path::{Path, PathBuf},
 };
 
 pub fn parse_file<T: Into<PathBuf>>(filepath: T) -> Result<syn::File, io::Error> {
@@ -42,7 +43,7 @@ pub fn parse_files<T: Into<PathBuf>>(path: T) -> Result<Vec<(String, syn::File)>
     Ok(files)
 }
 
-fn is_rust_file(path: &PathBuf) -> bool {
+fn is_rust_file(path: &Path) -> bool {
     path.is_file() && path.extension().unwrap().to_str().unwrap().eq("rs")
 }
 
@@ -55,39 +56,33 @@ fn is_rust_file(path: &PathBuf) -> bool {
 /// );
 /// assert_eq!(
 ///  module_name,
-/// "crate::tests::controllers::controller1".to_string()
+/// "crate::controllers::controller1".to_string()
 /// );
 /// ```
-pub fn extract_module_name_from_path(path: &String) -> String {
-    let mut path = path.to_string();
-    if path.ends_with(".rs") {
-        path = path.replace(".rs", "");
-    }
-    if path.ends_with("/mod") {
-        path = path.replace("/mod", "");
-    }
-    if path.ends_with("/lib") {
-        path = path.replace("/lib", "");
-    }
-    if path.ends_with("/main") {
-        path = path.replace("/main", "");
-    }
-    path = path.replace("./", "");
-    //remove first word
-    let path_vec = path
-        .split('/')
-        .enumerate()
-        .filter_map(|(idx, segment)| match (idx, segment) {
-            // Remove first segment and replace with `crate`, so that 'root/thing' becomes
-            // `crate::thing` in the end
-            (0, _) => Some("crate"),
-            // When using cargo workspaces, paths look like  './subcrate/src/my/module',
-            // so we need to remove the 'src' to produce `crate::my::module`
-            (1, "src") => None,
-            (_, segment) => Some(segment),
-        })
-        .collect::<Vec<&str>>();
-    path_vec.join("::")
+pub fn extract_module_name_from_path(path: &str) -> String {
+    let path = path
+        .trim_end_matches(".rs")
+        .trim_end_matches("/mod")
+        .trim_end_matches("/lib")
+        .trim_end_matches("/main")
+        .trim_start_matches("./");
+    let segments: Vec<_> = path.split('/').collect();
+
+    // In general, paths will look like `./src/my/module`, which should turn into `crate::my::module`.
+    // When using cargo workspaces, paths may look like `./subcrate/src/my/module`,
+    // `./crates/subcrate/src/my/module`, etc., so we need to remove anything up to `src`
+    // (or `tests`) to still produce `crate::my::module`.
+    let segments_inside_crate = match segments
+        .iter()
+        .position(|&segment| segment == "src" || segment == "tests")
+    {
+        Some(idx) => &segments[(idx + 1)..],
+        None => &segments,
+    };
+    let full_crate_path: Vec<_> = iter::once("crate")
+        .chain(segments_inside_crate.iter().copied())
+        .collect();
+    full_crate_path.join("::")
 }
 
 #[cfg(test)]
@@ -97,43 +92,41 @@ mod tests {
     #[test]
     fn test_extract_module_name_from_path() {
         assert_eq!(
-            extract_module_name_from_path(
-                &"./utoipa-auto-macro/tests/controllers/controller1.rs".to_string()
-            ),
-            "crate::tests::controllers::controller1"
+            extract_module_name_from_path("./utoipa-auto-macro/tests/controllers/controller1.rs"),
+            "crate::controllers::controller1"
         );
     }
 
     #[test]
     fn test_extract_module_name_from_mod() {
         assert_eq!(
-            extract_module_name_from_path(
-                &"./utoipa-auto-macro/tests/controllers/mod.rs".to_string()
-            ),
-            "crate::tests::controllers"
+            extract_module_name_from_path("./utoipa-auto-macro/tests/controllers/mod.rs"),
+            "crate::controllers"
         );
     }
 
     #[test]
     fn test_extract_module_name_from_lib() {
-        assert_eq!(
-            extract_module_name_from_path(&"./src/lib.rs".to_string()),
-            "crate"
-        );
+        assert_eq!(extract_module_name_from_path("./src/lib.rs"), "crate");
     }
 
     #[test]
     fn test_extract_module_name_from_main() {
-        assert_eq!(
-            extract_module_name_from_path(&"./src/main.rs".to_string()),
-            "crate"
-        );
+        assert_eq!(extract_module_name_from_path("./src/main.rs"), "crate");
     }
 
     #[test]
     fn test_extract_module_name_from_workspace() {
         assert_eq!(
-            extract_module_name_from_path(&"./server/src/routes/asset.rs".to_string()),
+            extract_module_name_from_path("./server/src/routes/asset.rs"),
+            "crate::routes::asset"
+        );
+    }
+
+    #[test]
+    fn test_extract_module_name_from_workspace_nested() {
+        assert_eq!(
+            extract_module_name_from_path("./crates/server/src/routes/asset.rs"),
             "crate::routes::asset"
         );
     }
@@ -141,7 +134,7 @@ mod tests {
     #[test]
     fn test_extract_module_name_from_folders() {
         assert_eq!(
-            extract_module_name_from_path(&"./src/routing/api/audio.rs".to_string()),
+            extract_module_name_from_path("./src/routing/api/audio.rs"),
             "crate::routing::api::audio"
         );
     }

--- a/utoipauto-core/src/string_utils.rs
+++ b/utoipauto-core/src/string_utils.rs
@@ -43,17 +43,16 @@ pub fn trim_parentheses(str: &str) -> String {
 /// );
 /// ```
 pub fn extract_paths(attributes: String) -> Vec<String> {
-    let paths;
-    let attributes = trim_parentheses(rem_first_and_last(&attributes.as_str()));
+    let attributes = trim_parentheses(rem_first_and_last(&attributes));
 
     if attributes.contains('|') {
         panic!("Please use the new syntax ! paths=\"(MODULE_TREE_PATH => MODULE_SRC_PATH) ;\"")
     }
-    if attributes.contains("=>") {
-        paths = extract_paths_arrow(attributes);
+    let paths = if attributes.contains("=>") {
+        extract_paths_arrow(attributes)
     } else {
-        paths = extract_paths_coma(attributes);
-    }
+        extract_paths_coma(attributes)
+    };
     if paths.is_empty() {
         panic!("utoipauto: No paths specified !")
     }


### PR DESCRIPTION
Fixes #7 with the first approach described in https://github.com/ProbablyClem/utoipauto/issues/7#issuecomment-1888588610.

This actually turned out to simplify the path conversion, as before allowing a single level of nesting was special-cased by replacing the first path segment with `crate`. The new algorithm no longer requires this, as it just replaces everything up to `/src`.

I've had to adjust the tests for the `extract_module_name_from_path` to match the new behaviour, but I have verified that the top-level tests still compile unchanged. I've also patched in my branch into my project and can confirm that it resolves my issue in #7 and that the macro outputs the same paths as I had manually specified.

In addition to the fix, I've taken the liberty to touch up some of the other macro functions with the same small clean-ups that I made to `extract_module_name_from_path` in a separate commit. Feel free to tell me off on that, I can rebase with only the first commit if you prefer.