### PR TITLE
Add custom ToSchema/ToResponse implementation support

### DIFF
--- a/tests/models.rs
+++ b/tests/models.rs
@@ -20,7 +20,7 @@ pub struct ModelSchemaImpl;
 impl<'s> ToSchema<'s> for ModelSchemaImpl {
     fn schema() -> (&'s str, RefOr<Schema>) {
         (
-            "string",
+            "ModelSchemaImpl",
             ObjectBuilder::new().schema_type(SchemaType::String).into(),
         )
     }
@@ -32,7 +32,7 @@ pub struct ModelSchemaImplFullName;
 impl<'s> utoipa::ToSchema<'s> for ModelSchemaImplFullName {
     fn schema() -> (&'s str, RefOr<Schema>) {
         (
-            "string",
+            "ModelSchemaImplFullName",
             ObjectBuilder::new().schema_type(SchemaType::String).into(),
         )
     }
@@ -44,7 +44,7 @@ pub struct ModelResponseImpl;
 impl<'s> ToResponse<'s> for ModelResponseImpl {
     fn response() -> (&'s str, RefOr<Response>) {
         (
-            "string",
+            "ModelResponseImpl",
             ResponseBuilder::new()
                 .description("A manual response")
                 .into(),
@@ -58,7 +58,7 @@ pub struct ModelResponseImplFullName;
 impl<'s> utoipa::ToResponse<'s> for ModelResponseImplFullName {
     fn response() -> (&'s str, RefOr<Response>) {
         (
-            "string",
+            "ModelResponseImplFullName",
             ResponseBuilder::new()
                 .description("A manual response")
                 .into(),

--- a/tests/models.rs
+++ b/tests/models.rs
@@ -1,5 +1,8 @@
 #![allow(dead_code)] // This code is used in the tests
-use utoipa::{ToResponse, ToSchema};
+use utoipa::{
+    openapi::{ObjectBuilder, RefOr, Response, ResponseBuilder, Schema, SchemaType},
+    ToResponse, ToSchema,
+};
 use utoipauto_macro::utoipa_ignore;
 
 #[derive(ToSchema)]
@@ -10,3 +13,55 @@ pub struct ModelResponse;
 #[utoipa_ignore]
 #[derive(ToSchema)]
 pub struct IgnoredModelSchema;
+
+// Manual implementation of ToSchema
+pub struct ModelSchemaImpl;
+
+impl<'s> ToSchema<'s> for ModelSchemaImpl {
+    fn schema() -> (&'s str, RefOr<Schema>) {
+        (
+            "string",
+            ObjectBuilder::new().schema_type(SchemaType::String).into(),
+        )
+    }
+}
+
+// Manual implementation of utoipa::ToSchema
+pub struct ModelSchemaImplFullName;
+
+impl<'s> utoipa::ToSchema<'s> for ModelSchemaImplFullName {
+    fn schema() -> (&'s str, RefOr<Schema>) {
+        (
+            "string",
+            ObjectBuilder::new().schema_type(SchemaType::String).into(),
+        )
+    }
+}
+
+// Manual implementation of ToSchema
+pub struct ModelResponseImpl;
+
+impl<'s> ToResponse<'s> for ModelResponseImpl {
+    fn response() -> (&'s str, RefOr<Response>) {
+        (
+            "string",
+            ResponseBuilder::new()
+                .description("A manual response")
+                .into(),
+        )
+    }
+}
+
+// Manual implementation of utoipa::ToResponse
+pub struct ModelResponseImplFullName;
+
+impl<'s> ToResponse<'s> for ModelResponseImplFullName {
+    fn response() -> (&'s str, RefOr<Response>) {
+        (
+            "string",
+            ResponseBuilder::new()
+                .description("A manual response")
+                .into(),
+        )
+    }
+}

--- a/tests/models.rs
+++ b/tests/models.rs
@@ -55,7 +55,7 @@ impl<'s> ToResponse<'s> for ModelResponseImpl {
 // Manual implementation of utoipa::ToResponse
 pub struct ModelResponseImplFullName;
 
-impl<'s> ToResponse<'s> for ModelResponseImplFullName {
+impl<'s> utoipa::ToResponse<'s> for ModelResponseImplFullName {
     fn response() -> (&'s str, RefOr<Response>) {
         (
             "string",

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -94,7 +94,7 @@ fn test_path_import_schema() {
             .expect("no components")
             .schemas
             .len(),
-        1
+        3, // 1 derive, 1 manual, 1 manual with utoipa::ToSchema
     )
 }
 
@@ -112,6 +112,6 @@ fn test_path_import_responses() {
             .expect("no components")
             .responses
             .len(),
-        1
+        3, // 1 derive, 1 manual, 1 manual with utoipa::ToResponse
     )
 }


### PR DESCRIPTION
some times users can't use derive macro ToSchema on custom Serialized/Deserialized Data or wrapper types that inner type is outside library and doesn't implement to schema or serilization:
```
#[derive(Debug)]
pub struct UUID(pub uuid::Uuid);

impl<'__s> ToSchema<'__s> for UUID {
    fn schema() -> (&'__s str, utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>) {
        (
            "UUID",
            utoipa::openapi::ObjectBuilder::new()
                .schema_type(utoipa::openapi::SchemaType::String)
                .into()
        )
    }
}

impl Into<uuid::Uuid> for UUID {
    fn into(self) -> uuid::Uuid {
        self.0
    }
}

impl<'de> Deserialize<'de> for UUID {
    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
    where
        D: Deserializer<'de> {
        <&str>::deserialize(deserializer).and_then(|s| {
            let u = uuid::Uuid::from_str(s).map_err(|e| de::Error::custom(format!("invalid uuid string: {}, {}", s, e)))?;

            Ok(Self(u))
        })
    }
}
```

i added the support in this pull request by discovering implementations of ToSchema and ToResponse