### PR TITLE
feat: discover schema with lifetimes and const generics

### DIFF
--- a/utoipauto/tests/default_features/const_generics.rs
+++ b/utoipauto/tests/default_features/const_generics.rs
@@ -1,0 +1,45 @@
+use utoipa::{OpenApi, ToSchema};
+use utoipauto_macro::utoipauto;
+
+#[derive(ToSchema)]
+#[aliases(ConstGenericStructSchema0 = ConstGenericStructSchema<0>)]
+pub struct ConstGenericStructSchema<const N: usize> {
+    foo: [u16; N],
+}
+
+#[derive(ToSchema)]
+#[aliases(DoubleConstGenericStructSchema0 = DoubleConstGenericStructSchema<0, 0>)]
+pub struct DoubleConstGenericStructSchema<const N: usize, const N2: usize> {
+    foo: [u16; N],
+    bar: [u16; N2],
+}
+
+#[derive(ToSchema)]
+#[aliases(ConstGenericEnumSchema0 = ConstGenericEnumSchema<0>)]
+pub enum ConstGenericEnumSchema<const N: usize> {
+    Foo([u16; N]),
+}
+
+#[derive(ToSchema)]
+#[aliases(DoubleConstGenericEnumSchema0 = DoubleConstGenericEnumSchema<0, 0>)]
+pub enum DoubleConstGenericEnumSchema<const N: usize, const N2: usize> {
+    Foo([u16; N], [u16; N2]),
+}
+
+/// Discover schema with const generics
+#[utoipauto(paths = "./utoipauto/tests/default_features/const_generics.rs")]
+#[derive(OpenApi)]
+#[openapi(info(title = "Const Generic API", version = "1.0.0"))]
+pub struct ConstGenericApiDocs {}
+
+#[test]
+fn test_const_generics() {
+    assert_eq!(
+        ConstGenericApiDocs::openapi()
+            .components
+            .expect("no components")
+            .schemas
+            .len(),
+        4
+    )
+}

--- a/utoipauto/tests/default_features/generics.rs
+++ b/utoipauto/tests/default_features/generics.rs
@@ -1,35 +1,100 @@
-use utoipa::ToSchema;
+use utoipa::OpenApi;
+use utoipauto_macro::utoipauto;
 
-#[derive(ToSchema)]
-pub struct NonGenericSchema;
-
-#[derive(ToSchema)]
-pub struct NonGenericSchema2;
-
-#[derive(ToSchema)]
-#[aliases(GenricModelSchema = GenericSchema < NonGenericSchema >)]
-pub struct GenericSchema<T> {
-    _data: T,
-}
-
-#[derive(ToSchema)]
-#[aliases(MultipleGenericModelSchema = MultipleGenericSchema < NonGenericSchema, NonGenericSchema2 >)]
-pub struct MultipleGenericSchema<T, U> {
-    _data: T,
-    _data2: U,
-}
-
-#[derive(ToSchema)]
+/// Combined Struct - type & const
+#[derive(utoipa::ToSchema)]
 #[aliases(
-MultipleAlaises1 = MultipleAliasesSchema < NonGenericSchema >,
-MultipleAlaises2 = MultipleAliasesSchema < NonGenericSchema2 >
+    TypeGenericAndConstGenericStructSchemaU32 = TypeGenericAndConstGenericStructSchema<core::primitive::u32, 1>,
+    TypeGenericAndConstGenericStructSchemaU64 = TypeGenericAndConstGenericStructSchema<core::primitive::u64, 2>,
 )]
-pub struct MultipleAliasesSchema<T> {
-    _data: T,
+pub struct TypeGenericAndConstGenericStructSchema<T, const N: usize> {
+    foo: T,
+    bar: [u16; N],
 }
 
-#[derive(ToSchema)]
-#[aliases(NestedGenericsSchema = NestedGenerics < GenericSchema < NonGenericSchema > >)]
-pub struct NestedGenerics<T> {
-    _data: T,
+/// Combined Struct - lifetime & type
+#[derive(utoipa::ToSchema)]
+#[aliases(
+    LifetimeAndTypeGenericGenericStructSchemaU32 = LifetimeAndTypeGenericGenericStructSchema<'a, core::primitive::u32>,
+    LifetimeAndTypeGenericGenericStructSchemaU64 = LifetimeAndTypeGenericGenericStructSchema<'a, core::primitive::u64>,
+)]
+pub struct LifetimeAndTypeGenericGenericStructSchema<'a, T> {
+    foo: &'a str,
+    bar: T,
+}
+
+/// Combined Struct - lifetime & const
+#[derive(utoipa::ToSchema)]
+#[aliases(LifetimeAndConstGenericGenericStructSchema2 = LifetimeAndConstGenericGenericStructSchema<'a, 2>)]
+pub struct LifetimeAndConstGenericGenericStructSchema<'a, const N: usize> {
+    foo: &'a str,
+    bar: [u16; N],
+}
+
+/// Combined Struct - lifetime & const & type
+#[derive(utoipa::ToSchema)]
+#[aliases(
+    LifetimeAndConstAndTypeGenericGenericStructSchema1 = LifetimeAndConstAndTypeGenericGenericStructSchema<'a, 5, 1, core::primitive::u32>,
+    LifetimeAndConstAndTypeGenericGenericStructSchema2 = LifetimeAndConstAndTypeGenericGenericStructSchema<'a, 6, 2, core::primitive::u64>,
+)]
+pub struct LifetimeAndConstAndTypeGenericGenericStructSchema<'a, const N: usize, const N2: usize, T> {
+    a: &'a str,
+    foo: [u16; N],
+    bar: [u16; N2],
+    t: T,
+}
+
+/// Combined Enum - type & const
+#[derive(utoipa::ToSchema)]
+#[aliases(
+    TypeGenericAndConstGenericEnumSchemaU32 = TypeGenericAndConstGenericEnumSchema<core::primitive::u32, 1>,
+    TypeGenericAndConstGenericEnumSchemaU64 = TypeGenericAndConstGenericEnumSchema<core::primitive::u64, 2>,
+)]
+pub enum TypeGenericAndConstGenericEnumSchema<T, const N: usize> {
+    Foo(T, [u16; N]),
+}
+
+/// Combined Enum - lifetime & type
+#[derive(utoipa::ToSchema)]
+#[aliases(
+    LifetimeAndTypeGenericGenericEnumSchemaU32 = LifetimeAndTypeGenericGenericEnumSchema<'a, core::primitive::u32>,
+    LifetimeAndTypeGenericGenericEnumSchemaU64 = LifetimeAndTypeGenericGenericEnumSchema<'a, core::primitive::u64>,
+)]
+pub enum LifetimeAndTypeGenericGenericEnumSchema<'a, T> {
+    Foo(&'a str, T),
+}
+
+/// Combined Enum - lifetime & const
+#[derive(utoipa::ToSchema)]
+#[aliases(LifetimeAndConstGenericGenericEnumSchema2 = LifetimeAndConstGenericGenericEnumSchema<'a, 2>)]
+pub enum LifetimeAndConstGenericGenericEnumSchema<'a, const N: usize> {
+    Foo(&'a str, [u16; N]),
+}
+
+/// Combined Enum - lifetime & const & type
+#[derive(utoipa::ToSchema)]
+#[aliases(
+    LifetimeAndConstAndTypeGenericGenericEnumSchema1 = LifetimeAndConstAndTypeGenericGenericEnumSchema<'a, 5, 1, core::primitive::u32>,
+    LifetimeAndConstAndTypeGenericGenericEnumSchema2 = LifetimeAndConstAndTypeGenericGenericEnumSchema<'a, 6, 2, core::primitive::u64>,
+)]
+pub enum LifetimeAndConstAndTypeGenericGenericEnumSchema<'a, const N: usize, const N2: usize, T> {
+    Foo(&'a str, [u16; N], [u16; N2], T),
+}
+
+/// Discover schema with generics
+#[utoipauto(paths = "./utoipauto/tests/default_features/generics.rs")]
+#[derive(OpenApi)]
+#[openapi(info(title = "Const Generic API", version = "1.0.0"))]
+pub struct GenericsApiDocs {}
+
+#[test]
+fn test_generics() {
+    assert_eq!(
+        GenericsApiDocs::openapi()
+            .components
+            .expect("no components")
+            .schemas
+            .len(),
+        14
+    )
 }

--- a/utoipauto/tests/default_features/lifetime_generics.rs
+++ b/utoipauto/tests/default_features/lifetime_generics.rs
@@ -1,0 +1,41 @@
+use utoipa::{OpenApi, ToSchema};
+use utoipauto_macro::utoipauto;
+
+#[derive(ToSchema)]
+pub struct LifetimeStructSchema<'a> {
+    foo: &'a str,
+}
+
+#[derive(ToSchema)]
+pub struct DoubleLifetimeStructSchema<'a, 'b> {
+    foo: &'a str,
+    bar: &'b str,
+}
+
+#[derive(ToSchema)]
+pub enum LifetimeEnumSchema<'a> {
+    Foo(&'a str),
+}
+
+#[derive(ToSchema)]
+pub enum DoubleLifetimeEnumSchema<'a, 'b> {
+    Foo(&'a str, &'b str),
+}
+
+/// Discover schema with lifetime generics
+#[utoipauto(paths = "./utoipauto/tests/default_features/lifetime_generics.rs")]
+#[derive(OpenApi)]
+#[openapi(info(title = "Lifetimes API", version = "1.0.0"))]
+pub struct LifetimesApiDocs {}
+
+#[test]
+fn test_lifetimes() {
+    assert_eq!(
+        LifetimesApiDocs::openapi()
+            .components
+            .expect("no components")
+            .schemas
+            .len(),
+        4
+    )
+}

--- a/utoipauto/tests/default_features/mod.rs
+++ b/utoipauto/tests/default_features/mod.rs
@@ -1,4 +1,7 @@
+pub mod const_generics;
 pub mod controllers;
 pub mod generics;
+pub mod lifetime_generics;
 pub mod models;
 pub mod test;
+pub mod type_generics;

--- a/utoipauto/tests/default_features/test.rs
+++ b/utoipauto/tests/default_features/test.rs
@@ -3,9 +3,9 @@ use utoipa::OpenApi;
 use utoipauto::utoipauto;
 
 use crate::default_features::controllers;
-use crate::default_features::generics::GenericSchema;
-use crate::default_features::generics::NonGenericSchema;
-use crate::default_features::generics::NonGenericSchema2;
+use crate::default_features::type_generics::GenericSchema;
+use crate::default_features::type_generics::NonGenericSchema;
+use crate::default_features::type_generics::NonGenericSchema2;
 
 // Discover from multiple controllers
 #[utoipauto(

--- a/utoipauto/tests/default_features/type_generics.rs
+++ b/utoipauto/tests/default_features/type_generics.rs
@@ -1,0 +1,35 @@
+use utoipa::ToSchema;
+
+#[derive(ToSchema)]
+pub struct NonGenericSchema;
+
+#[derive(ToSchema)]
+pub struct NonGenericSchema2;
+
+#[derive(ToSchema)]
+#[aliases(GenricModelSchema = GenericSchema < NonGenericSchema >)]
+pub struct GenericSchema<T> {
+    _data: T,
+}
+
+#[derive(ToSchema)]
+#[aliases(MultipleGenericModelSchema = MultipleGenericSchema < NonGenericSchema, NonGenericSchema2 >)]
+pub struct MultipleGenericSchema<T, U> {
+    _data: T,
+    _data2: U,
+}
+
+#[derive(ToSchema)]
+#[aliases(
+MultipleAlaises1 = MultipleAliasesSchema < NonGenericSchema >,
+MultipleAlaises2 = MultipleAliasesSchema < NonGenericSchema2 >
+)]
+pub struct MultipleAliasesSchema<T> {
+    _data: T,
+}
+
+#[derive(ToSchema)]
+#[aliases(NestedGenericsSchema = NestedGenerics < GenericSchema < NonGenericSchema > >)]
+pub struct NestedGenerics<T> {
+    _data: T,
+}

--- a/utoipauto/tests/generic_full_path/const_generics.rs
+++ b/utoipauto/tests/generic_full_path/const_generics.rs
@@ -1,0 +1,13 @@
+use utoipa::ToSchema;
+
+#[derive(ToSchema)]
+#[aliases(ConstGenericStructSchema0 = ConstGenericStructSchema<0>)]
+pub struct ConstGenericStructSchema<const N: usize> {
+    foo: [u16; N],
+}
+
+#[derive(ToSchema)]
+#[aliases(ConstGenericEnumSchema0 = ConstGenericEnumSchema<0>)]
+pub enum ConstGenericEnumSchema<const N: usize> {
+    Foo([u16; N]),
+}

--- a/utoipauto/tests/generic_full_path/mod.rs
+++ b/utoipauto/tests/generic_full_path/mod.rs
@@ -1,3 +1,4 @@
+mod const_generics;
 mod even_more_schemas;
 mod more_schemas;
 mod partial_imports;

--- a/utoipauto/tests/generic_full_path/test.rs
+++ b/utoipauto/tests/generic_full_path/test.rs
@@ -6,3 +6,21 @@ use utoipauto_macro::utoipauto;
 #[derive(OpenApi)]
 #[openapi(info(title = "Percentage API", version = "1.0.0"))]
 pub struct CrateApiDocs;
+
+/// Discover schema with const generics
+#[utoipauto(paths = "./utoipauto/tests/generic_full_path/const_generics.rs")]
+#[derive(OpenApi)]
+#[openapi(info(title = "Const Generic API", version = "1.0.0"))]
+pub struct ConstGenericApiDocs {}
+
+#[test]
+fn test_const_generics() {
+    assert_eq!(
+        ConstGenericApiDocs::openapi()
+            .components
+            .expect("no components")
+            .schemas
+            .len(),
+        2
+    )
+}


### PR DESCRIPTION
Fixed as issue where schema with lifetimes were ignored due to the overly eager `.generics.params.is_empty()` found [here](https://github.com/ProbablyClem/utoipauto/blob/eb04cbae37ac84ebd0763a27a856baeff3d3fa3d/utoipauto-core/src/discover.rs#L89) and [here](https://github.com/ProbablyClem/utoipauto/blob/eb04cbae37ac84ebd0763a27a856baeff3d3fa3d/utoipauto-core/src/discover.rs#L99).

Disclaimer that I'm not at all familiar with the inner workings of the crate so there may be unintended consequences I've overlooked.

