### PR TITLE
Properly interpolate `#[openapi]`-annotation with `TokenStreams`

### DIFF
--- a/utoipauto-core/src/attribute_utils.rs
+++ b/utoipauto-core/src/attribute_utils.rs
@@ -1,11 +1,11 @@
-use quote::ToTokens;
-use syn::Attribute;
+use proc_macro2::TokenStream;
+use syn::{punctuated::Punctuated, Attribute, Meta, Token};
 
 pub fn update_openapi_macro_attributes(
     macro_attibutes: &mut Vec<Attribute>,
-    uto_paths: &String,
-    uto_models: &String,
-    uto_responses: &String,
+    uto_paths: &TokenStream,
+    uto_models: &TokenStream,
+    uto_responses: &TokenStream,
 ) {
     let mut is_ok = false;
     for attr in macro_attibutes {
@@ -13,12 +13,21 @@ pub fn update_openapi_macro_attributes(
             continue;
         }
         is_ok = true;
-        let mut src_uto_macro = attr.to_token_stream().to_string();
-
-        src_uto_macro = src_uto_macro.replace("#[openapi()]", "");
-        src_uto_macro = src_uto_macro.replace("#[openapi(", "");
-        src_uto_macro = src_uto_macro.replace(")]", "");
-        *attr = build_new_openapi_attributes(src_uto_macro, uto_paths, uto_models, uto_responses);
+        match &attr.meta {
+            // #[openapi]
+            Meta::Path(_path) => {
+                *attr = build_new_openapi_attributes(Punctuated::new(), uto_paths, uto_models, uto_responses);
+            }
+            // #[openapi()] or #[openapi(attribute(...))]
+            Meta::List(meta_list) => {
+                let nested = meta_list
+                    .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+                    .expect("Expected a list of attributes inside #[openapi(...)]!");
+                *attr = build_new_openapi_attributes(nested, uto_paths, uto_models, uto_responses);
+            }
+            // This would be #[openapi = "foo"], which is not valid
+            Meta::NameValue(_) => panic!("Expected #[openapi(...)], but found #[openapi = value]!"),
+        }
     }
     if !is_ok {
         panic!("No utoipa::openapi Macro found !");
@@ -27,145 +36,134 @@ pub fn update_openapi_macro_attributes(
 
 /// Build the new openapi macro attribute with the newly discovered paths
 pub fn build_new_openapi_attributes(
-    src_uto_macro: String,
-    uto_paths: &String,
-    uto_models: &String,
-    uto_responses: &String,
+    nested_attributes: Punctuated<Meta, Token![,]>,
+    uto_paths: &TokenStream,
+    uto_models: &TokenStream,
+    uto_responses: &TokenStream,
 ) -> Attribute {
-    let paths = extract_paths(src_uto_macro.clone());
-    let schemas = extract_schemas(src_uto_macro.clone());
-    let responses = extract_responses(src_uto_macro.clone());
-    let src_uto_macro = remove_paths(src_uto_macro);
-    let src_uto_macro = remove_schemas(src_uto_macro);
-    let src_uto_macro = remove_responses(src_uto_macro);
-    let src_uto_macro = remove_components(src_uto_macro);
+    let paths = extract_paths(&nested_attributes);
+    let schemas = extract_schemas(&nested_attributes);
+    let responses = extract_responses(&nested_attributes);
+    let remaining_nested_attributes = remove_paths_and_components(nested_attributes);
 
-    let paths = format!("{}{}", uto_paths, paths);
-    let schemas = format!("{}{}", uto_models, schemas);
-    let responses = format!("{}{}", uto_responses, responses);
-    let src_uto_macro = format!(
-        "paths({}),components(schemas({}),responses({})),{}",
-        paths, schemas, responses, src_uto_macro
-    )
-    .replace(",,", ",");
+    let uto_paths = match uto_paths.is_empty() {
+        true => TokenStream::new(),
+        false => quote::quote!(#uto_paths,),
+    };
+    let uto_models = match uto_models.is_empty() {
+        true => TokenStream::new(),
+        false => quote::quote!(#uto_models,),
+    };
+    let uto_responses = match uto_responses.is_empty() {
+        true => TokenStream::new(),
+        false => quote::quote!(#uto_responses,),
+    };
+    let uto_macro = quote::quote!(
+        paths(#uto_paths #paths),components(schemas(#uto_models #schemas),responses(#uto_responses #responses)),
+        #remaining_nested_attributes
+    );
 
-    let stream: proc_macro2::TokenStream = src_uto_macro.parse().unwrap();
-
-    syn::parse_quote! { #[openapi( #stream )] }
+    syn::parse_quote! { #[openapi( #uto_macro )] }
 }
 
-fn remove_paths(src_uto_macro: String) -> String {
-    if src_uto_macro.contains("paths(") {
-        let paths = src_uto_macro.split("paths(").collect::<Vec<&str>>()[1];
-        let paths = paths.split(')').collect::<Vec<&str>>()[0];
-        src_uto_macro
-            .replace(format!("paths({})", paths).as_str(), "")
-            .replace(",,", ",")
-    } else {
-        src_uto_macro
+fn remove_paths_and_components(nested_attributes: Punctuated<Meta, Token![,]>) -> TokenStream {
+    let mut remaining = Vec::with_capacity(nested_attributes.len());
+    for meta in nested_attributes {
+        match meta {
+            Meta::List(list) if list.path.is_ident("paths") => (),
+            Meta::List(list) if list.path.is_ident("components") => (),
+            // These should be handled by removing `components`, this is just in case they occur outside of `components` for some reason.
+            Meta::List(list) if list.path.is_ident("schemas") => (),
+            Meta::List(list) if list.path.is_ident("responses") => (),
+            _ => remaining.push(meta),
+        }
     }
+    quote::quote!( #(#remaining),* )
 }
 
-fn remove_schemas(src_uto_macro: String) -> String {
-    if src_uto_macro.contains("schemas(") {
-        let schemas = src_uto_macro.split("schemas(").collect::<Vec<&str>>()[1];
-        let schemas = schemas.split(')').collect::<Vec<&str>>()[0];
-        src_uto_macro
-            .replace(format!("schemas({})", schemas).as_str(), "")
-            .replace(",,", ",")
-    } else {
-        src_uto_macro
+fn extract_paths(nested_attributes: &Punctuated<Meta, Token![,]>) -> TokenStream {
+    for meta in nested_attributes {
+        if let Meta::List(list) = meta {
+            if list.path.is_ident("paths") {
+                return list.tokens.clone();
+            }
+        }
     }
+
+    TokenStream::new()
 }
 
-fn remove_components(src_uto_macro: String) -> String {
-    if src_uto_macro.contains("components(") {
-        let components = src_uto_macro.split("components(").collect::<Vec<&str>>()[1];
-        let components = components.split(')').collect::<Vec<&str>>()[0];
-        src_uto_macro
-            .replace(format!("components({})", components).as_str(), "")
-            .replace(",,", ",")
-    } else {
-        src_uto_macro
+fn extract_schemas(nested_attributes: &Punctuated<Meta, Token![,]>) -> TokenStream {
+    for meta in nested_attributes {
+        if let Meta::List(list) = meta {
+            if list.path.is_ident("components") {
+                let nested = list
+                    .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+                    .expect("Expected a list of attributes inside components(...)!");
+                for meta in nested {
+                    if let Meta::List(list) = meta {
+                        if list.path.is_ident("schemas") {
+                            return list.tokens;
+                        }
+                    }
+                }
+            }
+        }
     }
+    TokenStream::new()
 }
 
-fn remove_responses(src_uto_macro: String) -> String {
-    if src_uto_macro.contains("responses(") {
-        let responses = src_uto_macro.split("responses(").collect::<Vec<&str>>()[1];
-        let responses = responses.split(')').collect::<Vec<&str>>()[0];
-        src_uto_macro
-            .replace(format!("responses({})", responses).as_str(), "")
-            .replace(",,", ",")
-    } else {
-        src_uto_macro
+fn extract_responses(nested_attributes: &Punctuated<Meta, Token![,]>) -> TokenStream {
+    for meta in nested_attributes {
+        if let Meta::List(list) = meta {
+            if list.path.is_ident("components") {
+                let nested = list
+                    .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+                    .expect("Expected a list of attributes inside components(...)!");
+                for meta in nested {
+                    if let Meta::List(list) = meta {
+                        if list.path.is_ident("responses") {
+                            return list.tokens;
+                        }
+                    }
+                }
+            }
+        }
     }
-}
-
-fn extract_paths(src_uto_macro: String) -> String {
-    if src_uto_macro.contains("paths(") {
-        let paths = src_uto_macro.split("paths(").collect::<Vec<&str>>()[1];
-        let paths = paths.split(')').collect::<Vec<&str>>()[0];
-        paths.to_string()
-    } else {
-        "".to_string()
-    }
-}
-
-fn extract_schemas(src_uto_macro: String) -> String {
-    if src_uto_macro.contains("schemas(") {
-        let schemas = src_uto_macro.split("schemas(").collect::<Vec<&str>>()[1];
-        let schemas = schemas.split(')').collect::<Vec<&str>>()[0];
-        schemas.to_string()
-    } else {
-        "".to_string()
-    }
-}
-
-fn extract_responses(src_uto_macro: String) -> String {
-    if src_uto_macro.contains("responses(") {
-        let responses = src_uto_macro.split("responses(").collect::<Vec<&str>>()[1];
-        let responses = responses.split(')').collect::<Vec<&str>>()[0];
-        responses.to_string()
-    } else {
-        "".to_string()
-    }
+    TokenStream::new()
 }
 #[cfg(test)]
 mod test {
+    use proc_macro2::TokenStream;
     use quote::ToTokens;
+    use syn::punctuated::Punctuated;
 
     #[test]
-    fn test_remove_paths() {
+    fn test_extract_paths() {
         assert_eq!(
-            super::remove_paths("description(test),paths(p1),info(test)".to_string()),
-            "description(test),info(test)".to_string()
+            super::extract_paths(&syn::parse_quote!(paths(p1))).to_string(),
+            "p1".to_string()
         );
     }
 
     #[test]
-    fn test_extract_paths() {
-        assert_eq!(super::extract_paths("paths(p1)".to_string()), "p1".to_string());
-    }
-
-    #[test]
     fn test_extract_paths_empty() {
-        assert_eq!(super::extract_paths("".to_string()), "".to_string());
+        assert_eq!(super::extract_paths(&Punctuated::new()).to_string(), "".to_string());
     }
 
     #[test]
     fn test_build_new_openapi_attributes() {
         assert_eq!(
             super::build_new_openapi_attributes(
-                "".to_string(),
-                &"./src".to_string(),
-                &"".to_string(),
-                &"".to_string(),
+                Punctuated::new(),
+                &quote::quote!(crate::api::test),
+                &TokenStream::new(),
+                &TokenStream::new(),
             )
-                .to_token_stream()
-                .to_string()
-                .replace(' ', ""),
-            "#[openapi(paths(./src),components(schemas(),responses()),)]".to_string()
+            .to_token_stream()
+            .to_string()
+            .replace(' ', ""),
+            "#[openapi(paths(crate::api::test,),components(schemas(),responses()),)]".to_string()
         );
     }
 
@@ -173,15 +171,15 @@ mod test {
     fn test_build_new_openapi_attributes_path_replace() {
         assert_eq!(
             super::build_new_openapi_attributes(
-                "paths(p1)".to_string(),
-                &"./src,".to_string(),
-                &"".to_string(),
-                &"".to_string(),
+                syn::parse_quote!(paths(p1)),
+                &quote::quote!(crate::api::test),
+                &TokenStream::new(),
+                &TokenStream::new(),
             )
             .to_token_stream()
             .to_string()
             .replace(' ', ""),
-            "#[openapi(paths(./src,p1),components(schemas(),responses()),)]".to_string()
+            "#[openapi(paths(crate::api::test,p1),components(schemas(),responses()),)]".to_string()
         );
     }
 
@@ -189,15 +187,15 @@ mod test {
     fn test_build_new_openapi_attributes_components() {
         assert_eq!(
             super::build_new_openapi_attributes(
-                "paths(p1)".to_string(),
-                &"./src,".to_string(),
-                &"model".to_string(),
-                &"".to_string()
+                syn::parse_quote!(paths(p1)),
+                &quote::quote!(crate::api::test),
+                &quote::quote!(model),
+                &TokenStream::new(),
             )
             .to_token_stream()
             .to_string()
             .replace(' ', ""),
-            "#[openapi(paths(./src,p1),components(schemas(model),responses()),)]".to_string()
+            "#[openapi(paths(crate::api::test,p1),components(schemas(model,),responses()),)]".to_string()
         );
     }
 
@@ -205,15 +203,15 @@ mod test {
     fn test_build_new_openapi_attributes_components_schemas_replace() {
         assert_eq!(
             super::build_new_openapi_attributes(
-                "paths(p1), components(schemas(m1))".to_string(),
-                &"./src,".to_string(),
-                &"model,".to_string(),
-                &"".to_string(),
+                syn::parse_quote!(paths(p1), components(schemas(m1))),
+                &quote::quote!(crate::api::test),
+                &quote::quote!(model),
+                &TokenStream::new(),
             )
             .to_token_stream()
             .to_string()
             .replace(' ', ""),
-            "#[openapi(paths(./src,p1),components(schemas(model,m1),responses()),)]".to_string()
+            "#[openapi(paths(crate::api::test,p1),components(schemas(model,m1),responses()),)]".to_string()
         );
     }
 
@@ -221,15 +219,15 @@ mod test {
     fn test_build_new_openapi_attributes_components_responses_replace() {
         assert_eq!(
             super::build_new_openapi_attributes(
-                "paths(p1), components(responses(r1))".to_string(),
-                &"./src,".to_string(),
-                &"".to_string(),
-                &"response,".to_string(),
+                syn::parse_quote!(paths(p1), components(responses(r1))),
+                &quote::quote!(crate::api::test),
+                &TokenStream::new(),
+                &quote::quote!(response),
             )
             .to_token_stream()
             .to_string()
             .replace(' ', ""),
-            "#[openapi(paths(./src,p1),components(schemas(),responses(response,r1)),)]".to_string()
+            "#[openapi(paths(crate::api::test,p1),components(schemas(),responses(response,r1)),)]".to_string()
         );
     }
 
@@ -237,15 +235,15 @@ mod test {
     fn test_build_new_openapi_attributes_components_responses_schemas_replace() {
         assert_eq!(
             super::build_new_openapi_attributes(
-                "paths(p1), components(responses(r1), schemas(m1))".to_string(),
-                &"./src,".to_string(),
-                &"model,".to_string(),
-                &"response,".to_string(),
+                syn::parse_quote!(paths(p1), components(responses(r1), schemas(m1))),
+                &quote::quote!(crate::api::test),
+                &quote::quote!(model),
+                &quote::quote!(response),
             )
             .to_token_stream()
             .to_string()
             .replace(' ', ""),
-            "#[openapi(paths(./src,p1),components(schemas(model,m1),responses(response,r1)),)]".to_string()
+            "#[openapi(paths(crate::api::test,p1),components(schemas(model,m1),responses(response,r1)),)]".to_string()
         );
     }
 
@@ -253,15 +251,15 @@ mod test {
     fn test_build_new_openapi_attributes_components_responses_schemas() {
         assert_eq!(
             super::build_new_openapi_attributes(
-                "paths(p1), components(responses(r1), schemas(m1))".to_string(),
-                &"./src,".to_string(),
-                &"".to_string(),
-                &"response,".to_string(),
+                syn::parse_quote!(paths(p1), components(responses(r1), schemas(m1))),
+                &quote::quote!(crate::api::test),
+                &TokenStream::new(),
+                &quote::quote!(response),
             )
             .to_token_stream()
             .to_string()
             .replace(' ', ""),
-            "#[openapi(paths(./src,p1),components(schemas(m1),responses(response,r1)),)]".to_string()
+            "#[openapi(paths(crate::api::test,p1),components(schemas(m1),responses(response,r1)),)]".to_string()
         );
     }
 
@@ -269,15 +267,45 @@ mod test {
     fn test_build_new_openapi_attributes_components_schemas_reponses() {
         assert_eq!(
             super::build_new_openapi_attributes(
-                "paths(p1), components(schemas(m1), responses(r1))".to_string(),
-                &"./src,".to_string(),
-                &"model,".to_string(),
-                &"".to_string(),
+                syn::parse_quote!(paths(p1), components(schemas(m1), responses(r1))),
+                &quote::quote!(crate::api::test),
+                &quote::quote!(model),
+                &TokenStream::new(),
             )
             .to_token_stream()
             .to_string()
             .replace(' ', ""),
-            "#[openapi(paths(./src,p1),components(schemas(model,m1),responses(r1)),)]".to_string()
+            "#[openapi(paths(crate::api::test,p1),components(schemas(model,m1),responses(r1)),)]".to_string()
+        );
+    }
+
+    #[test]
+    fn test_update_openapi_attributes_empty() {
+        let mut attrs = vec![syn::parse_quote!(#[openapi])];
+        super::update_openapi_macro_attributes(
+            &mut attrs,
+            &quote::quote!(crate::api::test),
+            &quote::quote!(model),
+            &TokenStream::new(),
+        );
+        assert_eq!(
+            attrs[0].to_token_stream().to_string().replace(' ', ""),
+            "#[openapi(paths(crate::api::test,),components(schemas(model,),responses()),)]".to_string()
+        );
+    }
+
+    #[test]
+    fn test_update_openapi_attributes_components_schemas_reponses() {
+        let mut attrs = vec![syn::parse_quote!(#[openapi(paths(p1), components(schemas(m1), responses(r1)))])];
+        super::update_openapi_macro_attributes(
+            &mut attrs,
+            &quote::quote!(crate::api::test),
+            &quote::quote!(model),
+            &TokenStream::new(),
+        );
+        assert_eq!(
+            attrs[0].to_token_stream().to_string().replace(' ', ""),
+            "#[openapi(paths(crate::api::test,p1),components(schemas(model,m1),responses(r1)),)]".to_string()
         );
     }
 }

--- a/utoipauto-core/src/file_utils.rs
+++ b/utoipauto-core/src/file_utils.rs
@@ -59,13 +59,14 @@ fn is_rust_file(path: &Path) -> bool {
 /// Extract the module name from the file path
 /// # Example
 /// ```
+/// # use quote::ToTokens as _;
 /// use utoipauto_core::file_utils::extract_module_name_from_path;
 /// let module_name = extract_module_name_from_path(
 ///    &"./utoipa-auto-macro/tests/controllers/controller1.rs".to_string(),
 /// "crate"
 /// );
 /// assert_eq!(
-///  module_name,
+///  module_name.to_token_stream().to_string().replace(' ', ""),
 /// "crate::controllers::controller1".to_string()
 /// );
 /// ```

--- a/utoipauto-macro/src/lib.rs
+++ b/utoipauto-macro/src/lib.rs
@@ -23,7 +23,7 @@ pub fn utoipauto(
     let mut openapi_macro = parse_macro_input!(item as syn::ItemStruct);
 
     // Discover all the functions with the #[utoipa] attribute
-    let (uto_paths, uto_models, uto_responses): (String, String, String) = discover(paths, &params);
+    let (uto_paths, uto_models, uto_responses) = discover(paths, &params);
 
     // extract the openapi macro attributes : #[openapi(openapi_macro_attibutes)]
     let openapi_macro_attibutes = &mut openapi_macro.attrs;


### PR DESCRIPTION
Replaces the String-based interpolation of the auto-discovered tokens into the manually annotated attributes with quoting via `TokenStream`s.

## What this PR fixes

When bumping to `utoipa` v5 / `utoipauto` v0.2, I noticed I was getting an error in my IDE (VS Code) on the `#[utoipauto]` annotation. Everything built fine when running tests / just building with `cargo`, but the macro crashed by `unwrap`ping an `Err` when run via rust-analyzer.

I was able to narrow the issue down to your handling of the original `#[openapi]` annotations on the struct deriving `OpenAPI`: `utoipauto` does its discovery and then pieces together the automatically discovered components with the existing annotations like `modifiers`, `tags`, etc. To do this, `update_openapi_macro_attributes` takes the whole attribute, converts it to a string via `to_token_stream` and then tries to strip `#[openapi(` at the start and `)]` at the end of the attribute, inserting everything in between into the newly generated annotation that is created as the output of the macro, containing also the automatically discovered paths. 

With `cargo`, this works because the `rustc` proc-macro server is relatively exact in its `to_string()` representation of the attribute: 

```rs
#[openapi(modifiers(&Addon1, &Addon2),\ninfo(title = \"Title\", version = \"v1\",),\nvariables((\"var\" =\n(description = \"Description\")),)),))]
```

(I've left out a bunch of stuff but you get the idea.)

Compare this to the `to_string()` representation we get when running under rust-analyzer:

```rs
# [openapi (modifiers (& Addon1 , & Addon2) , info (title = \"Title\" , version = \"v1\" ,) , variables ((\"var\" = (description = \"Description\")) ,)) ,))
```

As you can see, rust-analyzer's proc-macro server inserts additional whitespace in between the tokens inside that make up the token stream, which causes the substrings to no longer match and not be removed, and therefore causes the macro to output something like `#[openapi(paths(...), #[openapi(modifiers(...))] )]` containing first the auto-discovered paths, followed by _the entire original attribute_, which fails to re-parse as a `TokenStream` because attributes are not valid inside attributes.

Given that the [`impl Display for TokenStream`](https://doc.rust-lang.org/proc_macro/struct.TokenStream.html#impl-Display-for-TokenStream) explicitly cautions against matching against its output because it isn't stable by saying

> Note: the exact form of the output is subject to change, e.g. there might be changes in the whitespace used between tokens. Therefore, you should _not_ do any kind of simple substring matching on the output string (as produced by `to_string`) to implement a proc macro, because that matching might stop working if such changes happen. Instead, you should work at the `TokenTree` level, e.g. matching against `TokenTree::Ident`, `TokenTree::Punct`, or `TokenTree::Literal`.

I'm gonna suggest that this should be considered a bug in `utoipauto`.

## Changes made to fix this issue

The PR changes the interpolation inside `update_openapi_macro_attributes` to work on `TokenStream`s instead of `String`s. To do this, I had to create a larger change than I'd like, because I had to go back to `file_utils::exctract_module_name_from_path` to return an actual `Path` (this also fixes a bug where hyphens were only replaced with underscores in the crate name, but not module names, which for some reason existed in one of the tests), such that `discover_from_file` can now `parse_module_items` as `Path`s, such that `update_openapi_macro_attributes` can interpolate those paths into the original macro input on the level of `TokenStream`s / `quote`. This necessitated also rewriting the `extract_` and `remove_` functions in `attribute_utils` to work on `syn`'s `Attribute`/`Meta`.

I've ran the changes in the PR against your test suite, including the `acceptance` tests, and further verified the macro output is unchanged / correct in a regular build in the project I was having the issue in originally. I'll leave a comment for some test changes I had to make as a review.